### PR TITLE
README: Fix the broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a PowerShell Module and DSC Resources that can Get/Enable/Disable the So
 #### Installation
 
 This module can be installed from the PowerShell Gallery.  To do this run the following command from an elevated PowerShell prompt:
+
 ```Install-Module SoftwareTimestamping```
 
 Alternatively you can copy the SoftwareTimeStamping Folder into C:\Program Files\WindowsPowerShell\Modules
@@ -20,7 +21,7 @@ Alternatively you can copy the SoftwareTimeStamping Folder into C:\Program Files
 #### Test
 
 Please try out our validation guide!
-https://github.com/Microsoft/W32Time/blob/master/Timestamping/docs/Validation%20Guide%20-%20RS5%20-%20Software%20Timestamping.docx
+[Validation Guide - Software Timestamping.docx](./Timestamping/docs/Validation%20Guide%20-%20Software%20Timestamping.docx)
 
 ## Precision Time Protocol
 


### PR DESCRIPTION
This document has a link to a document that shall be located in the subfolder `./Timestamping/docs`. However, the referred file has changed its name. Hence, the link is broken. It also uses an absolute link to a specific version, which also a bit problematic. It'd better for it to have a relative link as advised in this commit.

By the way, this page has another link to the same documentation that is redirected via office-apps. This link doesn't always work in non edge browsers. But mostly it creates another version of the document , which complicates things for the user.